### PR TITLE
Fix resource.open_file which can no longer be called on directories

### DIFF
--- a/node.lua
+++ b/node.lua
@@ -428,10 +428,16 @@ local Queue = (function()
             module = ModuleJob,
         })[item.type])
 
-        local success, asset = pcall(resource.open_file, item.asset_name)
-        if not success then
-            print("CANNOT GRAB ASSET: ", asset)
-            return
+        local asset = null
+        if (item.type == "child" or item.type == "module") then
+            asset = item
+        else
+            local success, openfile = pcall(resource.open_file, item.asset_name)
+            if not success then
+                print("CANNOT GRAB ASSET: ", asset)
+                return
+            end
+            asset = openfile
         end
 
         -- an image may overlap another image


### PR DESCRIPTION
Previously it was possible to 'resource.open_file' directories. This made no sense as the resulting openfile object could not be consumed in any way. Version 0.9 now throws an error if you try to open_file a directory.

See https://info-beamer.com/blog/info-beamer-hosted-update-stable-0009