### PR TITLE
Smoother transitions between content

### DIFF
--- a/node.lua
+++ b/node.lua
@@ -440,8 +440,8 @@ local Queue = (function()
             asset = openfile
         end
 
-        -- an image may overlap another image
-        if #jobs > 0 and jobs[#jobs].type == "image" and item.type == "image" then
+        -- start all content at begining of transition
+        if #jobs > 0 then
             starts = starts - Config.get_switch_time()
         end
 

--- a/node.lua
+++ b/node.lua
@@ -428,10 +428,16 @@ local Queue = (function()
             module = ModuleJob,
         })[item.type])
 
-        local success, asset = pcall(resource.open_file, item.asset_name)
-        if not success then
-            print("CANNOT GRAB ASSET: ", asset)
-            return
+        local asset = null
+        if (item.type == "child" or item.type == "module") then
+            asset = item
+        else
+            local success, openfile = pcall(resource.open_file, item.asset_name)
+            if not success then
+                print("CANNOT GRAB ASSET: ", asset)
+                return
+            end
+            asset = openfile
         end
 
         -- an image may overlap another image


### PR DESCRIPTION
Previously only images overlapped to provide smooth transitions between them
Allows all content to overlap including videos so they are faded in / out of them playing