### PR TITLE
Revert previous event-slide display bug fix

### DIFF
--- a/node.lua
+++ b/node.lua
@@ -559,9 +559,7 @@ function node.render()
     end
 
     if walkin_state ~= "walkin" then
-
         event_slide = resource.render_child("event-slide")
-
         event_slide:draw(0, 0, WIDTH, HEIGHT, event_slide_alpha)
     end
 
@@ -569,7 +567,7 @@ function node.render()
         walkin_state = "walkin"
     end
 
-    if event_slide_alpha > 1 then
+    if event_slide_alpha >= 1 then
         walkin_state = "eventslide"
     end
 


### PR DESCRIPTION
It's actually a timing issue related to fast transition times. An option which will be removed soon anyway as it's not used.